### PR TITLE
Feature/chat - 채팅 화면 네비게이션 IOS 위치 이슈 수정

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -59,8 +59,8 @@ body {
 .navigation {
     position: fixed;
     bottom: 0;
-    bottom: constant(safe-area-inset-bottom);
-    bottom: env(safe-area-inset-bottom);
+    padding-bottom: constant(safe-area-inset-bottom);
+    padding-bottom: env(safe-area-inset-bottom);
 
     width: 100% !important;
     max-width: 500px;

--- a/components/chat/ChatInput.vue
+++ b/components/chat/ChatInput.vue
@@ -274,9 +274,8 @@ export default {
     z-index: 997;
     position: fixed;
     bottom: 9rem;
-
-    padding-bottom: env(safe-area-inset-bottom);
-    padding-bottom: constant(safe-area-inset-bottom);
+    bottom: calc(9rem + env(safe-area-inset-bottom));
+    bottom: calc(9rem + constant(safe-area-inset-bottom));
 }
 
 .chat-select-box {


### PR DESCRIPTION
## 📌 제목
채팅 화면 네비게이션 IOS 위치 이슈 수정


## ✨ 작업 내용
- Navigation.vue bottom -> padding-bottom으로 safe-area 처리 수정 (하단이 떠보이는 부분 개선 위해)
- ChatInput.vue bottom에 safe-area 계산 추가 
